### PR TITLE
Fixing conversion to VCF (ID missing)

### DIFF
--- a/R/manipulate.r
+++ b/R/manipulate.r
@@ -44,7 +44,7 @@ create_vcf <- function(chrom, pos, nea, ea, snp=NULL, ea_af=NULL, effect=NULL, s
 	)
 	VariantAnnotation::geno(hdr) <- S4Vectors::DataFrame(
 		Number = c("A", "A", "A", "A", "A", "A", "A"),
-		Type = c("Float", "Float", "Float", "Float", "Float", "Float"),
+		Type = c("Float", "Float", "Float", "Float", "Float", "Float", "String"),
 		Description = c(
 			"Effect size estimate relative to the alternative allele",
 			"Standard error of effect size estimate",

--- a/R/manipulate.r
+++ b/R/manipulate.r
@@ -30,6 +30,7 @@ create_vcf <- function(chrom, pos, nea, ea, snp=NULL, ea_af=NULL, effect=NULL, s
 	if(!is.null(pval)) gen[["LP"]] <- matrix(-log10(pval), nsnp)
 	if(!is.null(n)) gen[["SS"]] <- matrix(n, nsnp)
 	if(!is.null(ncase)) gen[["NC"]] <- matrix(ncase, nsnp)
+	if(!is.null(snp)) gen[["ID"]] <- matrix(snp, nsnp)
 	gen <- S4Vectors::SimpleList(gen)
 
 	gr <- GenomicRanges::GRanges(chrom, IRanges::IRanges(start=pos, end=pos + pmax(nchar(nea), nchar(ea)) - 1, names=snp))
@@ -42,7 +43,7 @@ create_vcf <- function(chrom, pos, nea, ea, snp=NULL, ea_af=NULL, effect=NULL, s
 		sample = name
 	)
 	VariantAnnotation::geno(hdr) <- S4Vectors::DataFrame(
-		Number = c("A", "A", "A", "A", "A", "A"),
+		Number = c("A", "A", "A", "A", "A", "A", "A"),
 		Type = c("Float", "Float", "Float", "Float", "Float", "Float"),
 		Description = c(
 			"Effect size estimate relative to the alternative allele",
@@ -50,9 +51,10 @@ create_vcf <- function(chrom, pos, nea, ea, snp=NULL, ea_af=NULL, effect=NULL, s
 			"-log10 p-value for effect estimate",
 			"Alternate allele frequency in the association study",
 			"Sample size used to estimate genetic effect",
-			"Number of cases used to estimate genetic effect"
+			"Number of cases used to estimate genetic effect",
+			"Study variant identifier"
 		),
-		row.names=c("ES", "SE", "LP", "AF", "SS", "NC")
+		row.names=c("ES", "SE", "LP", "AF", "SS", "NC", "ID")
 	)
 	VariantAnnotation::geno(hdr) <- subset(VariantAnnotation::geno(hdr), rownames(VariantAnnotation::geno(hdr)) %in% names(gen))
 


### PR DESCRIPTION
A bug fix for creation of GWAS VCF files from data frame. Added ID field, which was missing and consequently produced invalid GWAS VCF files which did not contain ID when read in or queried.