### PR TITLE
Proxy error

### DIFF
--- a/R/proxy.r
+++ b/R/proxy.r
@@ -46,7 +46,7 @@ get_ld_proxies <- function(rsid, bfile, searchspace=NULL, tag_kb=5000, tag_nsnp=
 	message("Finding proxies...")
 	system(cmd)
 
-	if (!file.exists(outcome))
+	if (!file.exists(outname))
 	{
 	  message("No proxies found for given SNPs")
 	  return(dplyr::tibble()) # So nrow is 0 for calling function

--- a/R/proxy.r
+++ b/R/proxy.r
@@ -48,14 +48,14 @@ get_ld_proxies <- function(rsid, bfile, searchspace=NULL, tag_kb=5000, tag_nsnp=
 
 	if (!file.exists(outcome))
 	{
-	  message("No proxies found")
+	  message("No proxies found for given SNPs")
 	  return(dplyr::tibble()) # So nrow is 0 for calling function
 	}
 	ld <- data.table::fread(paste0("gunzip -c ", outname), header=TRUE) %>%
 		dplyr::as_tibble() 
 	if(nrow(ld) == 0)
 	{
-	  message("No proxies found")
+	  message("No proxies found for given SNPs")
 	  return(ld)
 	}
 	ld %>%
@@ -67,6 +67,11 @@ get_ld_proxies <- function(rsid, bfile, searchspace=NULL, tag_kb=5000, tag_nsnp=
 	unlink(targetsname)
 	unlink(paste0(targetsname, c(".log", ".nosex")))
 	unlink(outname)
+	if(nrow(ld) == 0)
+	{
+	  message("No proxies found for given parameters")
+	  return(ld)
+	}
 	temp <- do.call(rbind, strsplit(ld[["PHASE"]], "")) %>% dplyr::as_tibble(.data, .name_repair="minimal")
 	names(temp) <- c("A1", "B1", "A2", "B2")
 	ld <- cbind(ld, temp) %>% dplyr::as_tibble(.data, .name_repair="minimal")


### PR DESCRIPTION
Sometimes when searching for proxy SNPs using local files, Plink will throw an error ("Error: No valid variants specified by --ld-snp/--ld-snps/--ld-snp-list") and output no file. This will cause a knock-on effect for the R package which itself will throw some (rather worrying) errors:
```
Error: No valid variants specified by --ld-snp/--ld-snps/--ld-snp-list.
Taking input= as a system command ('gunzip -c /user/work/jr18055/Rtemp/RtmpP8vEkP/fileaa72ecf4882.targets.ld.gz') and a variable has been used in the expression passed to `input=`. Please use fread(cmd=...). There is a security concern if you are creating an app, and the app could have a malicious user, and the app is not running in a secure environment; e.g. the app is running as root. Please read item 5 in the NEWS file for v1.11.6 for more information and for the option to suppress this message.
gzip: /user/work/jr18055/Rtemp/RtmpP8vEkP/fileaa72ecf4882.targets.ld.gz: No such file or directory
Error in `dplyr::filter()`:
! Problem while computing `..1 = .data[["R"]]^2 > tag_r2`.
Caused by error in `.data[["R"]]`:
! Column `R` not found in `.data`.
```

My solution would be to wrap the parts of the code which load this file around checks to ensure that 1) the file exists and 2) it contains any rows. 

It seems this problem can arise when the SNPs are not found in the local reference panel. This is most obvious when using a mismatched build (e.g. data is GRCh38 and panel is GRCh37) but can also occur when the data are imputed to contain more SNPs than the panel. Dropping those SNPs would likely be better than killing the entire process.