### PR TITLE
Suggested additional fixes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,8 +6,8 @@ Authors@R: c(
            comment = c(ORCID = "0000-0003-0920-1055")),
     person("Tom", "Palmer", , "tom.palmer@bristol.ac.uk", role = "ctb",
            comment = c(ORCID = "0000-0003-4655-4511")),
-  person("Rita", "Rasteiro", email="rita.rasteiro@bristol.ac.uk", role = c("ctb"),
-            comment=c(ORCID = "0000-0002-4217-3060"))
+    person("Rita", "Rasteiro", , "rita.rasteiro@bristol.ac.uk", role = "ctb",
+           comment = c(ORCID = "0000-0002-4217-3060"))
   )
 Description: Tools for dealing with GWAS summary data in VCF format.
     Includes reading, querying, writing, as well as helper functions such
@@ -25,6 +25,7 @@ Imports:
     genetics.binaRies,
     GenomeInfoDb,
     GenomicRanges,
+    gwasglue2,
     IRanges,
     magrittr,
     RCurl,
@@ -35,8 +36,7 @@ Imports:
     stringr,
     SummarizedExperiment,
     utils,
-    VariantAnnotation,
-    gwasglue2
+    VariantAnnotation
 Suggests: 
     knitr,
     rmarkdown,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,5 +47,6 @@ Remotes:
     github::mrcieu/genetics.binaRies,
     github::mrcieu/gwasglue2
 Encoding: UTF-8
+Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3
 SystemRequirements: GNU unzip

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
 # gwasvcf 0.1.2
 
-* New `gwasvcf_to_summaryset()` function to create a [gwasglue2](https://mrcieu.github.io/gwasglue2) Summaryset object from a vcf file
+* New `gwasvcf_to_summaryset()` function to create a [gwasglue2](https://mrcieu.github.io/gwasglue2) SummarySet object from a vcf file
 * Fixed error in `get_ld_proxies()` related with argument `validate`, deprecated in `as_tibble()` (tibble 2.0.0)

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,4 +2,3 @@
 
 * New `gwasvcf_to_summaryset()` function to create a [gwasglue2](https://mrcieu.github.io/gwasglue2) Summaryset object from a vcf file
 * Fixed error in `get_ld_proxies()` related with argument `validate`, deprecated in `as_tibble()` (tibble 2.0.0)
-  

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,4 @@
 # gwasvcf 0.1.2
-(Release date: 10-08-2023)
 
 * New gwasvcf_to_summaryset function to create a [gwasglue2](https://mrcieu.github.io/gwasglue2) Summaryset object from a vcf file
 * Fixed error in get_ld_proxies related with argument validate, deprecated in as_tibble() (tibble 2.0.0)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,5 @@
 # gwasvcf 0.1.2
 
-* New gwasvcf_to_summaryset function to create a [gwasglue2](https://mrcieu.github.io/gwasglue2) Summaryset object from a vcf file
-* Fixed error in get_ld_proxies related with argument validate, deprecated in as_tibble() (tibble 2.0.0)
+* New `gwasvcf_to_summaryset()` function to create a [gwasglue2](https://mrcieu.github.io/gwasglue2) Summaryset object from a vcf file
+* Fixed error in `get_ld_proxies()` related with argument `validate`, deprecated in `as_tibble()` (tibble 2.0.0)
   

--- a/R/gwasglue.R
+++ b/R/gwasglue.R
@@ -5,7 +5,7 @@
 #' Create a SummarySet
 #' 
 #' Returns a gwasglue2 SummarySet object
-#' @param vcf Path or URL to GWAS-VCF file or VCF object e.g. output from VariantAnnotation::readVcf, gwasvcftools::query_vcf or [query_gwas()]
+#' @param vcf Path or URL to GWAS-VCF file or VCF object e.g. output from [VariantAnnotation::readVcf()], [create_vcf()] or [query_gwas()]
 #' @export
 gwasvcf_to_summaryset <- function(vcf){
 	# get metadata from vcf and create metadata object

--- a/R/gwasglue.R
+++ b/R/gwasglue.R
@@ -19,4 +19,3 @@ gwasvcf_to_summaryset <- function(vcf){
 
     return(s)
 }
-

--- a/R/pval_index.r
+++ b/R/pval_index.r
@@ -1,6 +1,6 @@
 #' Create pval index from GWAS-VCF file
 #'
-#' Create a separate file called <id>.pvali which is used to speed up p-value queries
+#' Create a separate file called `<id>.pvali` which is used to speed up p-value queries.
 #'
 #' @param vcffile VCF filename
 #' @param maximum_pval Maximum p-value to include. Default = 0.05

--- a/R/query.r
+++ b/R/query.r
@@ -2,7 +2,7 @@
 #'
 #' Read in GWAS summary data with filters on datasets (if multiple datasets per file) and/or chromosome/position, rsids or pvalues. Chooses most optimal choice for the detected operating system. Typically chrompos searches are the fastest. On Windows, rsid or pvalue filters from a file will be slow. 
 #'
-#' @param vcf Path or URL to GWAS-VCF file or VCF object e.g. output from VariantAnnotation::readVcf or gwasvcftools::query_vcf
+#' @param vcf Path or URL to GWAS-VCF file or VCF object e.g. output from [VariantAnnotation::readVcf()] or [create_vcf()]
 #' @param chrompos Either vector of chromosome and position ranges e.g. "1:1000" or "1:1000-2000", or data frame with columns `chrom`, `start`, `end`.
 #' @param rsid Vector of rsids
 #' @param pval  P-value threshold (NOT -log10)

--- a/man/create_pval_index_from_vcf.Rd
+++ b/man/create_pval_index_from_vcf.Rd
@@ -14,5 +14,5 @@ create_pval_index_from_vcf(vcffile, maximum_pval, indexname)
 \item{indexname}{index file name to create. Deletes existing file if exists.}
 }
 \description{
-Create a separate file called <id>.pvali which is used to speed up p-value queries
+Create a separate file called \verb{<id>.pvali} which is used to speed up p-value queries.
 }

--- a/man/gwasvcf_to_summaryset.Rd
+++ b/man/gwasvcf_to_summaryset.Rd
@@ -7,7 +7,7 @@
 gwasvcf_to_summaryset(vcf)
 }
 \arguments{
-\item{vcf}{Path or URL to GWAS-VCF file or VCF object e.g. output from VariantAnnotation::readVcf, gwasvcftools::query_vcf or [query_gwas()]}
+\item{vcf}{Path or URL to GWAS-VCF file or VCF object e.g. output from \code{\link[VariantAnnotation:readVcf-methods]{VariantAnnotation::readVcf()}}, \code{\link[=create_vcf]{create_vcf()}} or \code{\link[=query_gwas]{query_gwas()}}}
 }
 \description{
 Returns a gwasglue2 SummarySet object

--- a/man/parse_chrompos.Rd
+++ b/man/parse_chrompos.Rd
@@ -7,7 +7,7 @@
 parse_chrompos(chrompos, radius = NULL)
 }
 \arguments{
-\item{chrompos}{Either vector of chromosome and position ranges e.g. "1:1000" or "1:1000-2000", or data frame with columns `chrom`, `start`, `end`.}
+\item{chrompos}{Either vector of chromosome and position ranges e.g. "1:1000" or "1:1000-2000", or data frame with columns \code{chrom}, \code{start}, \code{end}.}
 
 \item{radius}{Add radius to the specified positions. Default = NULL}
 }

--- a/man/query_chrompos_bcftools.Rd
+++ b/man/query_chrompos_bcftools.Rd
@@ -7,7 +7,7 @@
 query_chrompos_bcftools(chrompos, vcffile, id = NULL)
 }
 \arguments{
-\item{chrompos}{Either vector of chromosome and position ranges e.g. "1:1000" or "1:1000-2000", or data frame with columns `chrom`, `start`, `end`.}
+\item{chrompos}{Either vector of chromosome and position ranges e.g. "1:1000" or "1:1000-2000", or data frame with columns \code{chrom}, \code{start}, \code{end}.}
 
 \item{vcffile}{Path to .vcf.gz GWAS summary data file}
 

--- a/man/query_chrompos_file.Rd
+++ b/man/query_chrompos_file.Rd
@@ -7,7 +7,7 @@
 query_chrompos_file(chrompos, vcffile, id = NULL, build = "GRCh37")
 }
 \arguments{
-\item{chrompos}{Either vector of chromosome and position ranges e.g. "1:1000" or "1:1000-2000", or data frame with columns `chrom`, `start`, `end`.}
+\item{chrompos}{Either vector of chromosome and position ranges e.g. "1:1000" or "1:1000-2000", or data frame with columns \code{chrom}, \code{start}, \code{end}.}
 
 \item{vcffile}{Path to .vcf.gz GWAS summary data file}
 

--- a/man/query_chrompos_vcf.Rd
+++ b/man/query_chrompos_vcf.Rd
@@ -7,7 +7,7 @@
 query_chrompos_vcf(chrompos, vcf, id = NULL)
 }
 \arguments{
-\item{chrompos}{Either vector of chromosome and position ranges e.g. "1:1000" or "1:1000-2000", or data frame with columns `chrom`, `start`, `end`.}
+\item{chrompos}{Either vector of chromosome and position ranges e.g. "1:1000" or "1:1000-2000", or data frame with columns \code{chrom}, \code{start}, \code{end}.}
 
 \item{vcf}{VCF object (e.g. from readVcf)}
 

--- a/man/query_gwas.Rd
+++ b/man/query_gwas.Rd
@@ -24,9 +24,9 @@ query_gwas(
 )
 }
 \arguments{
-\item{vcf}{Path or URL to GWAS-VCF file or VCF object e.g. output from VariantAnnotation::readVcf or gwasvcftools::query_vcf}
+\item{vcf}{Path or URL to GWAS-VCF file or VCF object e.g. output from \code{\link[VariantAnnotation:readVcf-methods]{VariantAnnotation::readVcf()}} or \code{\link[=create_vcf]{create_vcf()}}}
 
-\item{chrompos}{Either vector of chromosome and position ranges e.g. "1:1000" or "1:1000-2000", or data frame with columns `chrom`, `start`, `end`.}
+\item{chrompos}{Either vector of chromosome and position ranges e.g. "1:1000" or "1:1000-2000", or data frame with columns \code{chrom}, \code{start}, \code{end}.}
 
 \item{rsid}{Vector of rsids}
 

--- a/man/vcflist_overlaps.Rd
+++ b/man/vcflist_overlaps.Rd
@@ -9,7 +9,7 @@ vcflist_overlaps(vcflist, chrompos)
 \arguments{
 \item{vcflist}{List of VCF objects, or list of VCF filenames, or mix of VCF objects and filenames}
 
-\item{chrompos}{Either vector of chromosome and position ranges e.g. "1:1000" or "1:1000-2000", or data frame with columns `chrom`, `start`, `end`.}
+\item{chrompos}{Either vector of chromosome and position ranges e.g. "1:1000" or "1:1000-2000", or data frame with columns \code{chrom}, \code{start}, \code{end}.}
 }
 \value{
 List of VCFs

--- a/vignettes/guide.Rmd
+++ b/vignettes/guide.Rmd
@@ -347,7 +347,7 @@ You may want to first harmonise the data so that all the non-effect alleles are 
 
 Although still under development, if compared with its predecessor, the [gwasglue2](https://mrcieu.github.io/gwasglue2/) package has several new features, including the use of S4 R objects.
 
-It is possible to create a `SummarySet` object from a GWAS-VCF file or VCF object e.g. output from `VariantAnnotation::readVcf()`, `gwasvcftools::query_vcf()` or `query_gwas()` using the `gwasvcf_to_summaryset()` function.
+It is possible to create a `SummarySet` object from a GWAS-VCF file or VCF object e.g. output from `VariantAnnotation::readVcf()`, `create_vcf()` or `query_gwas()` using the `gwasvcf_to_summaryset()` function.
 
 
 For example:

--- a/vignettes/guide.Rmd
+++ b/vignettes/guide.Rmd
@@ -358,4 +358,3 @@ summaryset <- readVcf(vcffile) %>%
 ```
 
 Once the `SummarySet` objects are created, it is possible to use `gwasglue2` to harmonise data, harmonise against a LD matrix, remap genomic coordinates to a different genome assembly, convert to other formats and more.
-


### PR DESCRIPTION
I have given this some more fixes.

* Markdown wasn't enabled for all helpfiles
* The old name for this package **gwasvcftools** was still used in several places
* I removed the release date from NEWS - because that wasn't accurate anymore - also release dates in the NEWS pages of pkgdown sites are autmatically added by pkgdown - so you don't need to add them anyway if a package is on CRAN.