### PR TITLE
fix warning message associated with fread in get_ld_proxies()

### DIFF
--- a/R/proxy.r
+++ b/R/proxy.r
@@ -55,7 +55,7 @@ get_ld_proxies <- function(rsid, bfile, searchspace=NULL, tag_kb=5000, tag_nsnp=
 		message("Index SNP not found in the reference panel")
 		return(ld)
 	}
-	ld <- data.table::fread(paste0("gunzip -c ", outname), header=TRUE) %>%
+	ld <- data.table::fread(cmd = paste0("gunzip -c ", outname), header = TRUE) %>%
 		dplyr::as_tibble(.name_repair="minimal") %>%
 		dplyr::filter(.data[["R"]]^2 > tag_r2) %>%
 		dplyr::filter(.data[["SNP_A"]] != .data[["SNP_B"]]) %>%


### PR DESCRIPTION
previously the shell command was passed to the `input` argument of `fread()` leading to a warning message (example below). I have specified the `cmd` argument now.  

example warning:

Taking input= as a system command ('gunzip -c /tmp/Rtmpr3kjvl/file5bb174ba8791.targets.ld.gz') and a variable has been used in the expression passed to `input=`. Please use fread(cmd=...). There is a security concern if you are creating an app, and the app could have a malicious user, and the app is not running in a secure environment; e.g. the app is running as root. Please read item 5 in the NEWS file for v1.11.6 for more information and for the option to suppress this message.