### PR TITLE
Proxy search now robust to VCFs with multiple samples

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -8,6 +8,7 @@ on:
   push:
     branches: [main, master]
   pull_request:
+  workflow_dispatch:
 
 name: R-CMD-check.yaml
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -41,7 +41,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -35,7 +35,6 @@ jobs:
           - {os: ubuntu-latest,  r: 'oldrel-2'}
           - {os: ubuntu-latest,  r: 'oldrel-3'}
           - {os: ubuntu-latest,  r: 'oldrel-4'}
-          - {os: ubuntu-latest,  r: 'oldrel-5'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -9,6 +9,8 @@ on:
     branches: [main, master]
   pull_request:
   workflow_dispatch:
+  schedule:
+    - cron: '37 2 * * WED' # run at 2:37am UTC on Wednesdays
 
 name: R-CMD-check.yaml
 

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -23,7 +23,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -48,5 +48,5 @@ Remotes:
     github::mrcieu/gwasglue2
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 SystemRequirements: GNU unzip, sqlite3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gwasvcf
 Title: Tools for Dealing with GWAS Summary Data in VCF Format
-Version: 0.1.4
+Version: 0.1.5
 Authors@R: c(
     person("Gibran", "Hemani", , "g.hemani@bristol.ac.uk", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0920-1055")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# gwasvcf 0.1.5
+
+* `proxy_match()` is now robust to VCFs with multiple samples (thanks @jwr-git)
+
 # gwasvcf 0.1.4
 
 * Add sqlite3 to DESCRIPTION SystemRequirements for `create_pval_index_from_vcf()`

--- a/R/proxy.r
+++ b/R/proxy.r
@@ -263,14 +263,14 @@ proxy_match <- function(vcf, rsid, bfile=NULL, proxies="yes", tag_kb=5000, tag_n
 		S4Vectors::DataFrame(row.names="PR", Number="1", Type="String", Description="Proxy rsid")
 	)
 	VariantAnnotation::geno(prox)[["ES"]][!sign_index] <- {unlist(VariantAnnotation::geno(prox)[["ES"]][!sign_index]) * -1} %>% as.list
-	VariantAnnotation::geno(prox)[["PR"]] <- matrix(ld[["SNP_B"]], length(ld[["SNP_B"]]), 1)
+	VariantAnnotation::geno(prox)[["PR"]] <- matrix(ld[["SNP_B"]], length(ld[["SNP_B"]]), ncol(prox), dimnames = list(NULL, colnames(prox)))
 
 	if(proxies == "only")
 	{
 		return(prox)
 	} else {
 		VariantAnnotation::geno(VariantAnnotation::header(o)) <- rbind(VariantAnnotation::geno(VariantAnnotation::header(o)), S4Vectors::DataFrame(row.names="PR", Number="1", Type="String", Description="Proxy rsid"))
-		VariantAnnotation::geno(o)[["PR"]] <- matrix(rep(NA, length(o)), length(o), 1)
+		VariantAnnotation::geno(o)[["PR"]] <- matrix(rep(NA, length(o)), length(o), ncol(prox))
 		return(BiocGenerics::rbind(o, prox))
 	}
 }


### PR DESCRIPTION
If a GWAS VCF file has multiple samples present, e.g.:
```
#CHROM  POS     ID      REF     ALT     QUAL    FILTER  INFO    FORMAT  chr14:47343403:47351247:clu_124338_     chr14:47504507:47530452:clu_124341_     chr14:47770753:47774434:clu_124346_     chr14:47775345:47776110:clu_124346_     chr14:47770753:48143720:clu_124346_
14      45731461        rs1951480       C       G       .       PASS    .       AF:ES:SE:LP:SS:ID       0.0819672:0.0793514:0.0455716:1.0881:2443:rs1951480     0.0819672:0.0296298:0.0386719:0.353041:2443:rs1951480   0.0819672:0:0:-0:2443:rs1951480      0.0819672:0:0:-0:2443:rs1951480 0.0819672:0:0:-0:2443:rs1951480
14      45731541        rs60084059      G       A       .       PASS    .       AF:ES:SE:LP:SS:ID       0.010929:0.107065:0.143472:0.341491:2443:rs60084059     0.010929:0.182674:0.100449:1.16129:2443:rs60084059      0.010929:0:0:-0:2443:rs60084059      0.010929:0:0:-0:2443:rs60084059 0.010929:0:0:-0:2443:rs60084059
```
then searching and finding proxies in this GWAS will cause an error due to incorrect dimensions of the resultant assay:
`
Error in method(object) : all assays must have the same nrow and ncol
`

This is caused by the `proxy_match` function setting only -- and always -- one column in the PR geno, despite the other geno entries containing multiple values.

Ensuring the PR geno entry follows the dimensions of `prox` makes this function robust to such cases.