### PR TITLE
Add fallback for proxy VCF construction failures on small/single-sample objects

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gwasvcf
 Title: Tools for Dealing with GWAS Summary Data in VCF Format
-Version: 0.1.5
+Version: 0.1.6
 Authors@R: c(
     person("Gibran", "Hemani", , "g.hemani@bristol.ac.uk", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0920-1055")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,20 @@
+# gwasvcf 0.1.6
+
+* Updates to the proxy VCF construction section inside `proxy_match()`.
+
+The new behavior is:
+
+1. Attempt the original implementation exactly as before.
+2. If that succeeds, return the result unchanged.
+3. If that fails, catch the error and rebuild the proxy VCF using a compatibility path that:
+
+   * extracts genotype fields as plain matrices first
+   * applies effect-sign flipping before VCF construction
+   * inserts the PR matrix before VCF construction
+   * then creates the VCF object once, instead of relying on post-hoc geno slot replacement
+
+This means existing successful cases continue using the original code path, and only problematic cases use the fallback (thanks @ywge03)
+
 # gwasvcf 0.1.5
 
 * `proxy_match()` is now robust to VCFs with multiple samples (thanks @jwr-git)

--- a/R/proxy.r
+++ b/R/proxy.r
@@ -306,7 +306,7 @@ proxy_match <- function(vcf, rsid, bfile=NULL, proxies="yes", tag_kb=5000, tag_n
 		})
 
 		if ("ES" %in% names(geno_list) && any(!sign_index)) {
-			geno_list[["ES"]][!sign_index, ] <-
+			geno_list[["ES"]][!sign_index, , drop = FALSE] <-
 				geno_list[["ES"]][!sign_index, , drop = FALSE] * -1
 		}
 

--- a/R/proxy.r
+++ b/R/proxy.r
@@ -247,23 +247,98 @@ proxy_match <- function(vcf, rsid, bfile=NULL, proxies="yes", tag_kb=5000, tag_n
 		QUAL=as.numeric(NA), 
 		FILTER="PASS"
 	)
-	prox <- VariantAnnotation::VCF(
-		rowRanges = gr,
-		colData = SummarizedExperiment::colData(e),
-		fixed = fixeddat,
-		info = VariantAnnotation::info(e),
-		exptData = list(
-			header = VariantAnnotation::header(e)
-		),
-		geno = S4Vectors::SimpleList(
-			lapply(VariantAnnotation::geno(e), `dimnames<-`, NULL)
+
+	# Try original implementation first to preserve existing behavior.
+	# Fall back only when VariantAnnotation's S4 geno replacement fails
+	# (e.g. small/single-sample VCF objects with subscript/dimension issues).
+	prox <- tryCatch({
+		prox0 <- VariantAnnotation::VCF(
+			rowRanges = gr,
+			colData = SummarizedExperiment::colData(e),
+			fixed = fixeddat,
+			info = VariantAnnotation::info(e),
+			exptData = list(
+				header = VariantAnnotation::header(e)
+			),
+			geno = S4Vectors::SimpleList(
+				lapply(VariantAnnotation::geno(e), `dimnames<-`, NULL)
+			)
 		)
-	)
-	VariantAnnotation::geno(VariantAnnotation::header(prox)) <- rbind(VariantAnnotation::geno(VariantAnnotation::header(prox)), 
-		S4Vectors::DataFrame(row.names="PR", Number="1", Type="String", Description="Proxy rsid")
-	)
-	VariantAnnotation::geno(prox)[["ES"]][!sign_index] <- {unlist(VariantAnnotation::geno(prox)[["ES"]][!sign_index]) * -1} %>% as.list
-	VariantAnnotation::geno(prox)[["PR"]] <- matrix(ld[["SNP_B"]], length(ld[["SNP_B"]]), ncol(prox), dimnames = list(NULL, colnames(prox)))
+
+		VariantAnnotation::geno(VariantAnnotation::header(prox0)) <- rbind(
+			VariantAnnotation::geno(VariantAnnotation::header(prox0)),
+			S4Vectors::DataFrame(
+				row.names = "PR",
+				Number = "1",
+				Type = "String",
+				Description = "Proxy rsid"
+			)
+		)
+
+		VariantAnnotation::geno(prox0)[["ES"]][!sign_index] <- {
+			unlist(VariantAnnotation::geno(prox0)[["ES"]][!sign_index]) * -1
+		} %>% as.list
+
+		VariantAnnotation::geno(prox0)[["PR"]] <- matrix(
+			ld[["SNP_B"]],
+			nrow = length(ld[["SNP_B"]]),
+			ncol = ncol(prox0),
+			dimnames = list(NULL, colnames(prox0))
+		)
+
+		prox0
+	}, error = function(err) {
+		message(
+			"Original proxy VCF construction failed; using compatibility fallback. Error: ",
+			conditionMessage(err)
+		)
+
+		# Fallback for problematic small / single-sample objects:
+		# build geno as plain matrices first, then construct the VCF once.
+		geno_list <- lapply(VariantAnnotation::geno(e), function(x) {
+			if (is.list(x) && !is.matrix(x)) {
+				x <- matrix(unlist(x), ncol = max(1L, ncol(e)))
+			} else if (!is.matrix(x)) {
+				x <- matrix(x, ncol = max(1L, ncol(e)))
+			}
+			dimnames(x) <- NULL
+			x
+		})
+
+		if ("ES" %in% names(geno_list) && any(!sign_index)) {
+			geno_list[["ES"]][!sign_index, ] <-
+				geno_list[["ES"]][!sign_index, , drop = FALSE] * -1
+		}
+
+		geno_list[["PR"]] <- matrix(
+			ld[["SNP_B"]],
+			nrow = nrow(ld),
+			ncol = max(1L, ncol(e))
+		)
+
+		prox1 <- VariantAnnotation::VCF(
+			rowRanges = gr,
+			colData = SummarizedExperiment::colData(e),
+			fixed = fixeddat,
+			info = VariantAnnotation::info(e),
+			exptData = list(
+				header = VariantAnnotation::header(e)
+			),
+			geno = S4Vectors::SimpleList(geno_list)
+		)
+
+		VariantAnnotation::geno(VariantAnnotation::header(prox1)) <- rbind(
+			VariantAnnotation::geno(VariantAnnotation::header(prox1)),
+			S4Vectors::DataFrame(
+				row.names = "PR",
+				Number = "1",
+				Type = "String",
+				Description = "Proxy rsid"
+			)
+		)
+
+		prox1
+	})
 
 	if(proxies == "only")
 	{

--- a/R/proxy.r
+++ b/R/proxy.r
@@ -313,7 +313,8 @@ proxy_match <- function(vcf, rsid, bfile=NULL, proxies="yes", tag_kb=5000, tag_n
 		geno_list[["PR"]] <- matrix(
 			ld[["SNP_B"]],
 			nrow = nrow(ld),
-			ncol = max(1L, ncol(e))
+			ncol = max(1L, ncol(e)),
+			dimnames = list(NULL, colnames(e))
 		)
 
 		prox1 <- VariantAnnotation::VCF(


### PR DESCRIPTION
### Summary

This PR keeps the existing `proxy_match()` proxy-construction logic as the default path, and adds a compatibility fallback that is only used when the original implementation fails during proxy VCF construction.

The goal is to fix a failure mode I encountered in my environment without changing behavior for users whose workflows already succeed with the current implementation.

In particular, the original code path is still attempted first. The fallback is only triggered if `VariantAnnotation` genotype-slot replacement fails during construction of the proxy VCF object.

### Background

`proxy_match()` currently builds a proxy `VCF` object and then modifies its `geno` slot after construction by:

* appending the `PR` geno header field
* flipping `ES` values when allele orientation requires sign reversal
* inserting a new `PR` genotype matrix to track the proxy rsID used

In my case, this post-construction S4 replacement pattern failed with a subscript/dimension-related error during manipulation of `geno(prox)`. The failure appears to be associated with small or effectively single-sample VCF-like objects, where `VariantAnnotation`'s replacement behavior can be fragile.

The functional intent of the original code is correct, so this PR does not replace that logic globally. Instead, it preserves the original implementation and adds a narrowly scoped fallback for the failing case.

### What this PR changes

This PR updates only the proxy VCF construction section inside `proxy_match()`.

The new behavior is:

1. Attempt the original implementation exactly as before.
2. If that succeeds, return the result unchanged.
3. If that fails, catch the error and rebuild the proxy VCF using a compatibility path that:

   * extracts genotype fields as plain matrices first
   * applies effect-sign flipping before VCF construction
   * inserts the `PR` matrix before VCF construction
   * then creates the `VCF` object once, instead of relying on post-hoc `geno` slot replacement

This means existing successful cases continue using the original code path, and only problematic cases use the fallback.